### PR TITLE
Add Return Type Declarations to Repository Methods

### DIFF
--- a/app/Repositories/ProductImagesRepository.php
+++ b/app/Repositories/ProductImagesRepository.php
@@ -24,7 +24,7 @@ class ProductImagesRepository implements ProductImagesRepositoryInterface
      * @param array $data - The data for the product image to be created.
      * @return \App\Models\ProductImage - The created ProductImage model instance.
      */
-    public function create(array $data)
+    public function create(array $data): ProductImage
     {
         return ProductImage::create($data);
     }

--- a/app/Repositories/ProductRepository.php
+++ b/app/Repositories/ProductRepository.php
@@ -27,7 +27,7 @@ class ProductRepository implements ProductRepositoryInterface
      * @param array $attributes - The data for the product to be created.
      * @return \App\Models\Product - The created Product model instance.
      */
-    public function create(array $attributes)
+    public function create(array $attributes): Product
     {
         return Product::create($attributes);
     }


### PR DESCRIPTION
Updated the `create` method in `ProductRepository` and `ProductImagesRepository` classes to include return type declarations. This change improves the readability and predictability of our code by providing clear expectations of what each function returns. The methods now clearly indicate that they return instances of the `Product` and `ProductImage` models respectively.